### PR TITLE
Not loading redis config values from Config.groovy

### DIFF
--- a/RedisGrailsPlugin.groovy
+++ b/RedisGrailsPlugin.groovy
@@ -52,7 +52,7 @@ class RedisGrailsPlugin {
     def documentation = "http://grails.org/plugin/redis"
 
     def doWithSpring = {
-        def redisConfigMap = application.config.grails.redis ?: [:]
+        def redisConfigMap = application.config.redis ?: [:]
 
         redisPoolConfig(JedisPoolConfig) {
             // used to set arbitrary config values without calling all of them out here or requiring any of them


### PR DESCRIPTION
The redisConfigMap is not loading values from the correct location.  I have fixed this.  The some of the unit tests are not passing, but I do not think that this change is creating the error in the unit tests. The unit test for the taglibs are failing.

This pull resolves https://github.com/grails-plugins/grails-redis/issues/6
