### PR TITLE
Invalidate pooled Jedis objects on JedisConnectionException in RedisService

### DIFF
--- a/grails-app/services/grails/plugin/redis/RedisService.groovy
+++ b/grails-app/services/grails/plugin/redis/RedisService.groovy
@@ -72,7 +72,7 @@ class RedisService {
     }
 
     def withRedis(Closure closure) {
-        Jedis redis = redisPool.getResource()
+        Jedis redis = redisPool.resource
         try {
             def ret = closure(redis)
             redisPool.returnResource(redis)


### PR DESCRIPTION
If a Jedis object throws a JedisConnectionException, it becomes invalid, and further attempts to use it may fail or behave strangely.  This patch intercepts those exceptions in RedisService.withRedis(), so that invalid Jedis objects aren't returned to the pool to be reused.  That solves the problem for RedisService and all its users, but I haven't read the whole plugin and similar issues may arise if Jedis objects are used directly elsewhere.
