### PR TITLE
Fixing docs to reflect proper withRedis usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The service overrides `propertyMissing` and `methodMissing` to delegate any miss
         
 It also provides a template method called `withRedis` that takes a closure as a parameter.  It passes a Jedis connection object to Redis into the closure.  The template method automatically gets an object out of the pool and ensures that it gets returned to the pool after the closure finishes (even if there's an error).
 
-    redisService.withRedis { 
+    redisService.withRedis { Jedis redis ->
         redis.set("foo", "bar")
     }
 


### PR DESCRIPTION
According to our experience, this call fails:

``` groovy
redisService.withRedis {
   redis.exists "someKey"
}
```

When we do this, we get the following exception:

```
Caused by MissingPropertyException: No such property: redis for class: stufftodo.ChicagoReaderEventSearchService
->>  26 | doCall in foo.BarService$_baz_closure1$$ENcncclc
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
|    76 | withRedis in grails.plugin.redis.RedisService
|    25 | shouldUpdate in foo.BarService$$ENcncclc
|    39 | handleMessage in     ''
^   680 | run in java.lang.Thread
```

However, when we call:

``` groovy
redisService.withRedis { Jedis redis ->
   redis.exists "someKey"
}
```

Everything works as expected.  This pull request updates the README to reflect proper API usage.

If we're mistaken and the first example should work as expected, we may have hit a bug. 
