### PR TITLE
Discard transactions if an exception occurs

### DIFF
--- a/grails-app/services/grails/plugin/redis/RedisService.groovy
+++ b/grails-app/services/grails/plugin/redis/RedisService.groovy
@@ -47,8 +47,13 @@ class RedisService {
     def withTransaction(Closure closure) {
         withRedis { Jedis redis ->
             Transaction transaction = redis.multi()
-            closure(transaction)
-            transaction.exec()
+            try {
+                closure(transaction)
+                transaction.exec()
+            } catch(Exception exception) {
+                transaction.discard()
+                throw exception
+            }
         }
     }
 

--- a/test/integration/grails/plugin/redis/RedisServiceTests.groovy
+++ b/test/integration/grails/plugin/redis/RedisServiceTests.groovy
@@ -222,6 +222,23 @@ class RedisServiceTests extends GroovyTestCase {
         }
     }
 
+    def testWithTransactionClosureException() {
+        redisService.withRedis { Jedis redis ->
+            assert redis.get("foo") == null
+        }
+
+        shouldFail{
+            redisService.withTransaction { Transaction transaction ->
+                transaction.set("foo", "bar")
+                throw new Exception("Something bad happened")
+            }
+        }
+
+        redisService.withRedis { Jedis redis ->
+            assert redis.get("foo") == null
+        }
+    }
+
     def testPropertyMissingGetterRetrievesStringValue() {
         assertNull redisService.foo
 


### PR DESCRIPTION
RedisService.withTransaction can leave a connection in a transaction if an exception occurs during the execution of the closure. This will return the connection to the pool in that state and  cause an exception to get raised on any subsequent calls with the exception:

`JedisDataException: Cannot use Jedis when in Multi. Please use JedisTransaction instead.` 
