### PR TITLE
added a returnAll parameter in withPipeline allowing to return all the results of the pipeline in order (pipeline.syncAndReturnAll()) or only those assigned to variables (pipeline.sync()). The latter remains the default

### DIFF
--- a/grails-app/services/grails/plugin/redis/RedisService.groovy
+++ b/grails-app/services/grails/plugin/redis/RedisService.groovy
@@ -36,11 +36,11 @@ class RedisService {
         return this
     }
 
-    def withPipeline(Closure closure) {
+    def withPipeline(Closure closure, Boolean returnAll=false) {
         withRedis { Jedis redis ->
             Pipeline pipeline = redis.pipelined()
             closure(pipeline)
-            pipeline.sync()
+            returnAll ? pipeline.syncAndReturnAll() : pipeline.sync()
         }
     }
 


### PR DESCRIPTION
The change is not breaking since the parameter is optional and its default value of false ensures that the previous behavior is kept when the parameter is not passed
