### PR TITLE
Revision to memoization to support method success in event of unreachable redis store

### DIFF
--- a/test/integration/grails/plugin/redis/RedisServiceTests.groovy
+++ b/test/integration/grails/plugin/redis/RedisServiceTests.groovy
@@ -1,17 +1,31 @@
 package grails.plugin.redis
 
+import grails.spring.BeanBuilder
+import redis.clients.jedis.exceptions.JedisConnectionException
+
 import static grails.plugin.redis.RedisService.NO_EXPIRATION_TTL
 import redis.clients.jedis.Jedis
 import redis.clients.jedis.Transaction
 
 class RedisServiceTests extends GroovyTestCase {
     def redisService
+    def redisServiceMock
+    def grailsApplication
 
     boolean transactional = false
 
     protected void setUp() {
         super.setUp()
-        redisService.flushDB()
+        redisServiceMock = mockRedisServiceForFailureTest(getNewInstanceOfBean(RedisService))
+
+        try {
+            redisService.flushDB()
+        }
+        catch (JedisConnectionException jce) {
+            // swallow connect exception so failure tests can proceed
+        }
+
+        assert redisService != redisServiceMock
     }
 
     void testFlushDB() {
@@ -27,6 +41,26 @@ class RedisServiceTests extends GroovyTestCase {
         redisService.withRedis { Jedis redis ->
             assertEquals 0, redis.dbSize()
         }
+    }
+
+    /**
+     * This test method ensures that memoization method succeeds in the event of an unreachable redis store
+     */
+    void testMemoizeKeyWithoutRedis() {
+        def calledCount = 0
+        def cacheMissClosure = {
+            calledCount += 1
+            return "foo"
+        }
+        def cacheMissResult = redisServiceMock.memoize("mykey", cacheMissClosure)
+
+        assertEquals 1, calledCount
+        assertEquals "foo", cacheMissResult
+
+        cacheMissResult = redisServiceMock.memoize("mykey", cacheMissClosure)
+
+        assertEquals 2, calledCount
+        assertEquals "foo", cacheMissResult
     }
 
     void testMemoizeKey() {
@@ -53,6 +87,27 @@ class RedisServiceTests extends GroovyTestCase {
         def result = redisService.memoize("mykey", 60) { "foo" }
         assertEquals "foo", result
         assertTrue NO_EXPIRATION_TTL < redisService.ttl("mykey")
+    }
+
+    /**
+     * Test hashfield memoization with an unreachable redis store
+     */
+    void testMemoizeHashFieldWithoutRedis() {
+        def calledCount = 0
+        def cacheMissClosure = {
+            calledCount += 1
+            return "foo"
+        }
+        def cacheMissResult = redisServiceMock.memoizeHashField("mykey", "first", cacheMissClosure)
+
+        assertEquals 1, calledCount
+        assertEquals "foo", cacheMissResult
+
+        cacheMissResult = redisServiceMock.memoizeHashField("mykey", "first", cacheMissClosure)
+
+        // should have hit the cache, not called our method again
+        assertEquals 2, calledCount
+        assertEquals "foo", cacheMissResult
     }
 
     void testMemoizeHashField() {
@@ -87,6 +142,28 @@ class RedisServiceTests extends GroovyTestCase {
         assertTrue NO_EXPIRATION_TTL < redisService.ttl("mykey")
     }
 
+    /**
+     * Tests hash memoization with an unreachable redis store
+     */
+    def testMemoizeHashWithoutRedis() {
+        def calledCount = 0
+        def expectedHash = [foo: 'bar', baz: 'qux']
+        def cacheMissClosure = {
+            calledCount += 1
+            return expectedHash
+        }
+        def cacheMissResult = redisServiceMock.memoizeHash("mykey", cacheMissClosure)
+
+        assertEquals 1, calledCount
+        assertEquals expectedHash, cacheMissResult
+
+        def cacheHitResult = redisServiceMock.memoizeHash("mykey", cacheMissClosure)
+
+        // should have hit the cache, not called our method again
+        assertEquals 2, calledCount
+        assertEquals expectedHash, cacheHitResult
+    }
+
     def testMemoizeHash() {
         def calledCount = 0
         def expectedHash = [foo: 'bar', baz: 'qux']
@@ -113,6 +190,34 @@ class RedisServiceTests extends GroovyTestCase {
         def result = redisService.memoizeHash("mykey", 60) { expectedHash }
         assertEquals expectedHash, result
         assertTrue NO_EXPIRATION_TTL < redisService.ttl("mykey")
+    }
+
+    /**
+     * testing list memoization with an unreachable redis store
+     */
+    def testMemoizeListWithoutRedis() {
+        def book1 = "book1"
+        def book2 = "book2"
+        def book3 = "book3"
+        List books = [book1, book2, book3]
+
+        def calledCount = 0
+        def cacheMissClosure = {
+            calledCount += 1
+            return books
+        }
+
+        def cacheMissList = redisServiceMock.memoizeList("mykey", cacheMissClosure)
+
+        assertEquals 1, calledCount
+        assertEquals([book1, book2, book3], cacheMissList)
+
+        List cacheHitList = redisServiceMock.memoizeList("mykey", cacheMissClosure)
+
+        // cache hit, don't call closure again
+        assertEquals 2, calledCount
+        assertEquals([book1, book2, book3], cacheHitList)
+        assertEquals cacheMissList, cacheHitList
     }
 
     def testMemoizeList() {
@@ -148,7 +253,34 @@ class RedisServiceTests extends GroovyTestCase {
         assertEquals([book1], result)
         assertTrue NO_EXPIRATION_TTL < redisService.ttl("mykey")
     }
-    
+
+    /**
+     * tests set memoization with an unreachable redis store
+     */
+    def testMemoizeSetWithoutRedis() {
+        def book1 = "book1"
+        def book2 = "book2"
+        def book3 = "book3"
+        def bookSet = [book1, book2, book3]as Set
+
+        def calledCount = 0
+        def cacheMissClosure = {
+            calledCount += 1
+            return bookSet
+        }
+
+        Set cacheMissSet = redisServiceMock.memoizeSet("mykey", cacheMissClosure)
+
+        assertEquals 1, calledCount
+        assertEquals([book1, book2, book3] as Set, cacheMissSet)
+
+        def cacheHitSet = redisServiceMock.memoizeSet("mykey", cacheMissClosure)
+
+        // cache hit, don't call closure again
+        assertEquals 2, calledCount
+        assertEquals([book1, book2, book3] as Set, cacheHitSet)
+        assertEquals cacheMissSet, cacheHitSet
+    }
 
     def testMemoizeSet() {
         def book1 = "book1"
@@ -273,5 +405,28 @@ class RedisServiceTests extends GroovyTestCase {
         def result = shouldFail { redisService.methodThatDoesNotExistAndNeverWill() }
 
         assert result?.startsWith("No signature of method: redis.clients.jedis.Jedis.methodThatDoesNotExistAndNeverWill")
+    }
+
+    // utility method for assisting in test setup
+    def getNewInstanceOfBean(Class clazz) {
+        String beanName = "prototype${clazz.name}"
+        BeanBuilder beanBuilder = new BeanBuilder(grailsApplication.mainContext)
+
+        beanBuilder.beans {
+            "$beanName"(clazz) { bean ->
+                bean.autowire = 'byName'
+            }
+        }
+
+        beanBuilder.createApplicationContext().getBean(beanName)
+    }
+
+    def mockRedisServiceForFailureTest(RedisService svc) {
+        def redisPoolMock = new Object()
+        redisPoolMock.metaClass.getResource =  { ->
+            throw new JedisConnectionException('Generated by a mocked redisPool')
+        }
+        svc.redisPool = redisPoolMock
+        return svc
     }
 }


### PR DESCRIPTION
Changed up the memoization methods to not fail in the event of your redis (cache) layer being unreachable.  In this case, simply simulates a cache miss.  When using a read through cache, you might rather your application slow down in the event of the cache layer being unavailable as opposed to just stop working completely.  This is slightly more aligned with how the rails redis plugin works.

Added tests for the various memoization methods to exercise the feature (can run them with no avail redis server), however they will bypass in the event a redis server is found so not to disrupt the natural flow of the test suite.

Also tried to respect the spacing convention of the project a little better this time, heh.  And bumped the plugin version's defect release, but defer to you to change.
