### PR TITLE
Allow string value for grails.redis.port in properties file

### DIFF
--- a/RedisGrailsPlugin.groovy
+++ b/RedisGrailsPlugin.groovy
@@ -85,7 +85,7 @@ class RedisGrailsPlugin {
         }
 
         def host = redisConfigMap?.host ?: 'localhost'
-        def port = redisConfigMap?.port ?: Protocol.DEFAULT_PORT
+        def port = redisConfigMap?.port ? (redisConfigMap?.port.class == String && redisConfigMap?.port.isInteger() ? redisConfigMap?.port.toInteger() : redisConfigMap?.port) : Protocol.DEFAULT_PORT
         def timeout = redisConfigMap?.timeout ?: Protocol.DEFAULT_TIMEOUT
         def password = redisConfigMap?.password ?: null
         def database = redisConfigMap?.database ?: Protocol.DEFAULT_DATABASE
@@ -110,6 +110,5 @@ class RedisGrailsPlugin {
                 redisPool = ref("redisPool${key}")
             }
         }
-
     }
 }


### PR DESCRIPTION
Hey! Hopefully you're not sick of all my pull requests yet. So my application overwrites certain Config.groovy properties in an external properties file. There may be a need for to overwrite the `grails.redis.host` and `grails.redis.port` in that file. Since it is a `.properties` file instead of `.groovy` all of the properties are read in as strings. The `port` is required to be an `Integer` so I added a check that if the property is a `String` it converts it to an `Integer`.

Let me know what you think. Thanks
