### PR TITLE
Use latest Jedis 2.4.2 & make integration test compatible to both Redis 2.6.x and 2.8.x

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -17,7 +17,7 @@ grails.project.dependency.resolution = {
     }
 
     dependencies {
-	    compile 'redis.clients:jedis:2.2.0'
+	    compile 'redis.clients:jedis:2.4.2'
 		compile 'com.google.code.gson:gson:2.2.4'
     }
 

--- a/test/integration/grails/plugin/redis/RedisServiceTests.groovy
+++ b/test/integration/grails/plugin/redis/RedisServiceTests.groovy
@@ -83,7 +83,7 @@ class RedisServiceTests extends GroovyTestCase {
     }
 
     void testMemoizeKeyWithExpire() {
-        assertEquals NO_EXPIRATION_TTL, redisService.ttl("mykey")
+        assertTrue 0 > redisService.ttl("mykey")
         def result = redisService.memoize("mykey", 60) { "foo" }
         assertEquals "foo", result
         assertTrue NO_EXPIRATION_TTL < redisService.ttl("mykey")
@@ -136,7 +136,7 @@ class RedisServiceTests extends GroovyTestCase {
     }
 
     void testMemoizeHashFieldWithExpire() {
-        assertEquals NO_EXPIRATION_TTL, redisService.ttl("mykey")
+        assertTrue 0 > redisService.ttl("mykey")
         def result = redisService.memoizeHashField("mykey", "first", 60) { "foo" }
         assertEquals "foo", result
         assertTrue NO_EXPIRATION_TTL < redisService.ttl("mykey")
@@ -186,7 +186,7 @@ class RedisServiceTests extends GroovyTestCase {
 
     void testMemoizeHashWithExpire() {
         def expectedHash = [foo: 'bar', baz: 'qux']
-        assertEquals NO_EXPIRATION_TTL, redisService.ttl("mykey")
+        assertTrue 0 > redisService.ttl("mykey")
         def result = redisService.memoizeHash("mykey", 60) { expectedHash }
         assertEquals expectedHash, result
         assertTrue NO_EXPIRATION_TTL < redisService.ttl("mykey")
@@ -248,7 +248,7 @@ class RedisServiceTests extends GroovyTestCase {
 
     def testMemoizeListWithExpire() {
         def book1 = "book1"
-        assertEquals NO_EXPIRATION_TTL, redisService.ttl("mykey")
+        assertTrue 0 > redisService.ttl("mykey")
         def result = redisService.memoizeList("mykey", 60) { [book1] }
         assertEquals([book1], result)
         assertTrue NO_EXPIRATION_TTL < redisService.ttl("mykey")
@@ -310,7 +310,7 @@ class RedisServiceTests extends GroovyTestCase {
 
     def testMemoizeSetWithExpire() {
         def book1 = "book1"
-        assertEquals NO_EXPIRATION_TTL, redisService.ttl("mykey")
+        assertTrue 0 > redisService.ttl("mykey")
         def result = redisService.memoizeSet("mykey", 60) { [book1] as Set }
         assertEquals([book1] as Set, result)
         assertTrue NO_EXPIRATION_TTL < redisService.ttl("mykey")


### PR DESCRIPTION
Hello!

grails-redis user requested to release backported version of Jedis.
(Currently latest Jedis is 2.4.2, and user requested v2.2.1 + back port to v2.2.2.)
See issue : https://github.com/xetorthio/jedis/issues/589

I'm not grails user, but I did give it a try.
I changed Jedis version and fix some unit tests.
(it's not related to Jedis, it's related to Redis version - ttl result is different with Redis 2.6 and 2.8. see http://redis.io/commands/ttl)

It seems that latest Jedis works flawlessly in point of view as grails-redis tests.
(I'm using "grails test-app") 
So I request to merge this change.

Please review and comment!
