### PR TITLE
Warn instead of failing hard on bad poolConfig parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ Release Notes
 * 1.4.4 - released 2/16/2014 - Allow for the 'expire' field to optionally be a variable in annotations instead of a constant string only, just like the 'key' works
 * 1.5.0 - released 2/24/2014 - addition of `@MemoizeObject` annotation which allows for JSON representation to be stored in redis, moved log level of "optional" redis connections down to info, better handling/transformation of config values
 * 1.5.1 - released 3/16/2014 - updated to Jedis 2.4.2
+* 1.5.2 - released TBD - Do not fail hard on bad poolConfig parameters
 
 [redisgorm]: http://grails.github.com/inconsequential/redis/
 [redis]: http://redis.io

--- a/RedisGrailsPlugin.groovy
+++ b/RedisGrailsPlugin.groovy
@@ -22,7 +22,7 @@ import redis.clients.jedis.Protocol
 
 class RedisGrailsPlugin {
 
-    def version = "1.5.0"
+    def version = "1.5.2"
     def grailsVersion = "2.0.0 > *"
     def author = "Ted Naleid"
     def authorEmail = "contact@naleid.com"
@@ -79,8 +79,12 @@ class RedisGrailsPlugin {
         "${poolBean}"(JedisPoolConfig) {
             // used to set arbitrary config values without calling all of them out here or requiring any of them
             // any property that can be set on RedisPoolConfig can be set here
-            redisConfigMap.poolConfig.each { configkey, value ->
-                delegate.setProperty(configkey, value)
+            redisConfigMap.poolConfig.each { configKey, value ->
+                if( delegate.hasProperty(configKey) ) {
+                    delegate.setProperty(configKey, value)
+                } else {
+                    log.warn "Redis pool configuration parameter ${configKey} does not exist on JedisPoolConfig"
+                }
             }
         }
 


### PR DESCRIPTION
- Warn instead of failing hard on bad poolConfig parameters
- Apparently Redis 2.8 changed the return value of TTL for non-existent keys to -2 (instead of -1), so I've updated the tests with the assumption they would be run against 2.8. The core code still works, and actually slightly better. There's two cases where it checks the TTL, and if it's -1, it will issue the EXPIRE command. For a non-existent key, that would previously call expire, but now it will actually skip the EXPIRE on the key that does not exist, saving one round trip.
- The taglib tests failed for me locally because there's an assumption that they run in the order of the file, though grails does not guarantee that behavior
