### PR TITLE
add `cacheNull: false`  option to `memoizeObject`, fixes #35

### DIFF
--- a/grails-app/services/grails/plugin/redis/RedisService.groovy
+++ b/grails-app/services/grails/plugin/redis/RedisService.groovy
@@ -343,10 +343,11 @@ class RedisService {
 
         String memoizedJson = memoize(key, options) { ->
             def original = closure()
+            if (original == null && options.cacheNull == false) return null
             gson.toJson(original)
         }
 
-        gson.fromJson(memoizedJson, clazz)
+        gson.fromJson((String)memoizedJson, clazz)
     }
 
     // deletes all keys matching a pattern (see redis "keys" documentation for more)


### PR DESCRIPTION
This adds a `cacheNull: false` flag to the new `memoizeObject` method and fixes issue #35.
