### PR TITLE
Issue with masked errors is withTransaction()

### DIFF
--- a/src/groovy/grails/plugin/redis/RedisService.groovy
+++ b/src/groovy/grails/plugin/redis/RedisService.groovy
@@ -67,11 +67,12 @@ class RedisService {
             Transaction transaction = redis.multi()
             try {
                 closure(transaction)
-                transaction.exec()
             } catch(Exception exception) {
                 transaction.discard()
                 throw exception
             }
+
+            transaction.exec()
         }
     }
 


### PR DESCRIPTION
A call to `Transaction.exec()` triggers the client send and then sets `isInMulti` and `isInWatch` to false. If there is a subsequent exception thrown, it is masked because the call to `Transaction.discard()` throws an exception when the client is no longer in multi.

Moving the call to `Transaction.exec()` out of the try/catch will allow its own failures to bubble up, but still catch any exceptions thrown by the user's closure.

