### PR TITLE
Exclude web-app folder from plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
     gradleWrapperVersion = project.gradleWrapperVersion
 }
 
-version "2.0.0"
+version "2.0.1"
 group "org.grails.plugins"
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/src/main/groovy/redis/RedisGrailsPlugin.groovy
+++ b/src/main/groovy/redis/RedisGrailsPlugin.groovy
@@ -19,7 +19,8 @@ class RedisGrailsPlugin extends Plugin {
             "grails-app/services/test/**",
             "gradle/**",
             "test/**",
-            "src/test/**"
+            "src/test/**",
+            "web-app/**"
     ]
 
     def title = "Redis Plugin" // Headline display name of the plugin


### PR DESCRIPTION
Ran into some issues with assets from the redis plugin overriding assets from other plugins, I think it can all be excluded.

![screen shot 2015-05-04 at 11 52 42 am](https://cloud.githubusercontent.com/assets/981551/7457743/874d240c-f254-11e4-88f6-7d2ebbddb1a8.png)

