### PR TITLE
Remove the explicit build dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
     gradleWrapperVersion = project.gradleWrapperVersion
 }
 
-version "2.0.2"
+version "2.0.3"
 group "org.grails.plugins"
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
@@ -97,5 +97,5 @@ bintray {
 }
 
 
-bintrayUpload.dependsOn build, sourcesJar, javadocJar
+bintrayUpload.dependsOn sourcesJar, javadocJar
 


### PR DESCRIPTION
Having `build` as a required step puts all the jars in the lib folder and makes this artifact 40mb+.  This isn't required as these should be managed at the parent when packaging.