### PR TITLE
Update gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-grailsVersion=3.0.0.RC2
+grailsVersion=3.0.12
 gradleWrapperVersion=2.3


### PR DESCRIPTION
This fixes the naming issue that is still there for the artifact name.  See 2 at http://blog.agileorbit.com/2015/10/07/Publishing-Grails-3-Plugins.html