### PR TITLE
Fix groovydoc task classpath

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -61,7 +61,9 @@ dependencies {
     api 'redis.clients:jedis:5.1.0'
     api 'com.google.code.gson:gson:2.10.1'
 
-    documentation 'com.github.javaparser:javaparser-core:3.25.7'
+    documentation('com.github.javaparser:javaparser-core:3.25.7') {
+        transitive = false
+    }
 }
 
 groovydoc {


### PR DESCRIPTION
Exclude transitives from javaparser-core dependency to remove `guava` and `google-collections` from the documentation classpath.

Fixes #138 