### PR TITLE
Fix: use config.get('grails.redis', Map) to support new Grails versions

### DIFF
--- a/plugin/src/main/groovy/redis/RedisGrailsPlugin.groovy
+++ b/plugin/src/main/groovy/redis/RedisGrailsPlugin.groovy
@@ -40,7 +40,7 @@ class RedisGrailsPlugin extends Plugin {
 
     Closure doWithSpring() {
         { ->
-            def redisConfigMap = grailsApplication.config.getProperty('grails.redis') ?: [:]
+            def redisConfigMap = grailsApplication.config.get('grails.redis') ?: [:]
 
             RedisConfigurationUtil.configureService(delegate, redisConfigMap, "", RedisService)
             redisConfigMap?.connections?.each { connection ->


### PR DESCRIPTION
In Grails 6+, `getProperty()` returns only String. This causes `grails.redis` config to always return empty map.  
This PR replaces `getProperty()` with `get('grails.redis', Map, [:])` to correctly retrieve Redis config as Map.
（RedisGrailsPlugin 获取 grails.redis 总是返回[:]，因为升级后grails 的getProperty只支持返回string）。