### PR TITLE
Grails 7.0.0-M5

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -45,7 +45,7 @@ repositories {
 
 dependencies {
     implementation platform("org.apache.grails:grails-bom:${versions.get('grailsVersion')}")
-    implementation 'com.bertramlabs.plugins:asset-pipeline-gradle'
+    implementation 'cloud.wondrify:asset-pipeline-gradle'
     implementation 'org.apache.grails:grails-gradle-plugins'
     implementation "org.nosphere.apache.rat:org.nosphere.apache.rat.gradle.plugin:${versions.get('ratVersion')}"
     implementation "org.gradle.crypto.checksum:org.gradle.crypto.checksum.gradle.plugin:${versions.get('gradleCryptoChecksumVersion')}"

--- a/examples/redis-demo/build.gradle
+++ b/examples/redis-demo/build.gradle
@@ -18,7 +18,7 @@
  */
 
 plugins {
-    id 'com.bertramlabs.asset-pipeline'
+    id 'cloud.wondrify.asset-pipeline'
     id 'org.apache.grails.gradle.grails-web'
     id 'org.apache.grails.gradle.grails-gsp'
 }
@@ -42,7 +42,7 @@ dependencies {
     implementation 'org.apache.grails:grails-web-boot'
     implementation 'org.webjars.npm:jquery'
 
-    runtimeOnly 'com.bertramlabs.plugins:asset-pipeline-grails'
+    runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.apache.tomcat:tomcat-jdbc'
     runtimeOnly 'org.fusesource.jansi:jansi'

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,7 @@
 
 projectVersion=5.0.0-SNAPSHOT
 
-# TODO: This is a work around since the bom does not support exclusions and spring forces groovy version 4.0.26
-groovy.version=4.0.27
-grailsVersion=7.0.0-M4
+grailsVersion=7.0.0-M5
 javaVersion=17
 gradleCryptoChecksumVersion=1.4.0
 ratVersion=0.8.1

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -29,6 +29,43 @@ group = 'org.apache.grails'
 dependencies {
 
     implementation platform("org.apache.grails:grails-bom:$grailsVersion")
+    compileOnly "org.apache.grails:grails-core", {
+        // requires groovy & is a grails plugin
+    }
+    compileOnly "org.apache.grails:grails-services", {
+        // project has a dynamic service
+    }
+    compileOnly "org.apache.grails:grails-web-boot", {
+        // project uses gsp features, including taglib
+    }
+
+    // Spring includes will be in any end grails application, do not export them
+    // as people may use undertow instead of tomcat, etc
+    compileOnly "org.springframework.boot:spring-boot-autoconfigure"
+    compileOnly "org.springframework.boot:spring-boot-starter"
+    compileOnly "org.springframework.boot:spring-boot-starter-actuator"
+    compileOnly "org.springframework.boot:spring-boot-starter-logging"
+    compileOnly "org.springframework.boot:spring-boot-starter-validation"
+    compileOnly "org.springframework.boot:spring-boot-starter-tomcat"
+
+    testImplementation platform("org.apache.grails:grails-bom:$grailsVersion")
+    testImplementation 'org.apache.grails:grails-testing-support-web'
+    testImplementation 'org.spockframework:spock-core'
+    testImplementation "org.springframework.boot:spring-boot-autoconfigure"
+    testImplementation "org.springframework.boot:spring-boot-starter"
+    testImplementation "org.springframework.boot:spring-boot-starter-actuator"
+    testImplementation "org.springframework.boot:spring-boot-starter-logging"
+    testImplementation "org.springframework.boot:spring-boot-starter-validation"
+    testImplementation "org.springframework.boot:spring-boot-starter-tomcat"
+    testImplementation "org.apache.grails:grails-core", {
+        // requires groovy & is a grails plugin
+    }
+    testImplementation "org.apache.grails:grails-services", {
+        // project has a dynamic service
+    }
+    testImplementation "org.apache.grails:grails-web-boot", {
+        // project uses gsp features, including taglib
+    }
 
     api 'redis.clients:jedis', {
         // api: Jedis, JedisConnectionException
@@ -37,31 +74,6 @@ dependencies {
     api 'com.google.code.gson:gson', {
         // api: Gson(transform)
     }
-    api 'org.springframework:spring-beans', {
-        // api: @Autowired(transform)
-    }
-    api 'org.springframework:spring-core', {
-        // api: Opcodes(transform)
-    }
-
-    implementation 'org.apache.grails.data:grails-datamapping-core', {
-        // impl: @Transactional(runtime)
-    }
-    implementation 'org.apache.grails.views:grails-web-taglib', {
-        // Project has a taglib
-    }
-
-    compileOnly 'org.apache.grails.bootstrap:grails-bootstrap', {
-        // comp: @PluginSource(source)
-    }
-    compileOnly 'org.apache.grails:grails-core', { // Provided as this is a Grails Plugin
-        // api GrailsApplication, Holders(transform)
-        // impl: GrailsApp, GrailsAutoConfiguration, Plugin
-    }
-    compileOnly 'org.apache.groovy:groovy' // Provided as this is a Grails Plugin
-
-    testImplementation 'org.apache.grails:grails-testing-support-web'
-    testImplementation 'org.spockframework:spock-core'
 }
 
 apply {
@@ -70,4 +82,8 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/reproducible-config.gradle')
+}
+
+grails {
+    springDependencyManagement = false
 }


### PR DESCRIPTION
PR upgrades to Grails 7.0.0-M5 and going forward should be more compatible with future grails versions (assuming API compatibility).

One of the reasons we're switching from `implementation` to `compileOnly` is to ensure transitive dependencies are not exported on accident.  The asset plugin was one of the first plugins to no longer exports dependencies.  This plugin was failing until I added the base dependencies to this project.  I've also updated the dependencies to use `org.apache.grails` coordinates instead of nested coordinates (which we consider private / should not be used outside of grails-core).  

The pom for this library is now: 


      <?xml version="1.0" encoding="UTF-8"?>
      <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
        <!-- This module was also published with a richer model, Gradle metadata,  -->
        <!-- which should be used instead. Do not delete the following line which  -->
        <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
        <!-- that they should prefer consuming it instead. -->
        <!-- do_not_remove: published-with-gradle-metadata -->
        <modelVersion>4.0.0</modelVersion>
        <groupId>org.apache.grails</groupId>
        <artifactId>grails-redis</artifactId>
        <version>5.0.0-SNAPSHOT</version>
        <dependencies>
          <dependency>
            <groupId>redis.clients</groupId>
            <artifactId>jedis</artifactId>
            <scope>compile</scope>
            <version>6.0.0</version>
          </dependency>
          <dependency>
            <groupId>com.google.code.gson</groupId>
            <artifactId>gson</artifactId>
            <scope>compile</scope>
            <version>2.13.1</version>
          </dependency>
        </dependencies>
        <name>Grails Redis Plugin</name>
        <description>This Plugin provides access to Redis and various utilities (service, annotations, etc) for caching.</description>
        <url>https://github.com/apache/grails-redis</url>
        <licenses>
          <license>
            <name>The Apache Software License, Version 2.0</name>
            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
            <distribution>repo</distribution>
          </license>
        </licenses>
        <scm>
          <url>https://github.com/apache/grails-redis</url>
          <connection>scm:git@github.com:apache/grails-redis.git</connection>
          <developerConnection>scm:git@github.com:apache/grails-redis.git</developerConnection>
        </scm>
        <issueManagement>
          <system>GitHub Issues</system>
          <url>https://github.com/apache/grails-redis/issues</url>
        </issueManagement>
        <developers>
          <developer>
            <id>tednaleid</id>
            <name>Ted Naleid</name>
          </developer>
          <developer>
            <id>burtbeckwith</id>
            <name>Burt Beckwith</name>
          </developer>
          <developer>
            <id>christianoestreich</id>
            <name>Christian Oestreich</name>
          </developer>
          <developer>
            <id>briancoles</id>
            <name>Brian Coles</name>
          </developer>
          <developer>
            <id>michaelcameron</id>
            <name>Michael Cameron</name>
          </developer>
          <developer>
            <id>johnengelman</id>
            <name>John Engelman</name>
          </developer>
          <developer>
            <id>davidseiler</id>
            <name>David Seiler</name>
          </developer>
          <developer>
            <id>jordonsaardchit</id>
            <name>Jordon Saardchit</name>
          </developer>
          <developer>
            <id>florianlangenhahn</id>
            <name>Florian Langenhahn</name>
          </developer>
          <developer>
            <id>germansancho</id>
            <name>German Sancho</name>
          </developer>
          <developer>
            <id>johnmulhern</id>
            <name>John Mulhern</name>
          </developer>
          <developer>
            <id>shaunjurgemeyer</id>
            <name>Shaun Jurgemeyer</name>
          </developer>
          <developer>
            <id>puneetbehl</id>
            <name>Puneet Behl</name>
          </developer>
        </developers>
      </project>
